### PR TITLE
skip 'Uptime:' while saving config

### DIFF
--- a/vrancid
+++ b/vrancid
@@ -148,6 +148,7 @@ sub ShowConfiguration {
 	}
 	next if (/^system (shutdown message from|going down )/i);
 	next if (/^\{(master|backup)(:\d+)?\}/);
+	next if (/^Uptime:/);
 	$lines++;
 
 	/^database header mismatch: / && return(-1);


### PR DESCRIPTION
skip uptime, because it changes on every run of rancid.
